### PR TITLE
fix empty results when error caught by try

### DIFF
--- a/johnnydep/walk.py
+++ b/johnnydep/walk.py
@@ -79,9 +79,9 @@ def node_license_walk(path:str="./node_modules/"):
 
                 entry["required_by"] = []
                 entry["summary"] = d["description"]
-                
+                res.append(entry)
             except:
                 pass
-            res.append(entry)
+            
     print(json.dumps(res, indent=4))
     return res


### PR DESCRIPTION
The try was filling up the results with when an error was thrown.
`{}`